### PR TITLE
getGithubApiV2.sh to support latest

### DIFF
--- a/tools/getGithubApiV2.sh
+++ b/tools/getGithubApiV2.sh
@@ -95,7 +95,10 @@ tags_array=($tags)
 
 # Determine the version to download
 if [ -z "$SPECIFIC_VERSION" ]; then
-  # Get latest version
+  VERSION_TO_INSTALL="latest"
+elif [ "$SPECIFIC_VERSION" = "latest" ]; then
+  VERSION_TO_INSTALL="latest"
+elif [ "$SPECIFIC_VERSION" = "newest" ]; then
   VERSION_TO_INSTALL="${tags_array[0]}"
 else
   VERSION_TO_INSTALL="$SPECIFIC_VERSION"


### PR DESCRIPTION
User can now specify "--version newest" and "--version latest".

"newest" will read/sort all the release tags from the repo and pick the newest. This matches the previous behaviour, when no specific version was chosen.

"latest" assumes, that there is a corresponding docker image on ghcr.io having an assigned label "latest".

If no version is specified (specific version or newest), the new default is latest.