### PR TITLE
docs: revamp README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,53 +6,104 @@
 [![npm](https://img.shields.io/npm/v/topoviewer?label=npm)](https://www.npmjs.com/package/topoviewer)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/asadarafat/topoviewer)
 
-TopoViewer turns infrastructure topology into interactive diagrams.
+**Topology as Code for infrastructure, network, and service diagrams.**
 
-Give TopoViewer a topology model, a stylesheet, and optionally a telemetry
-mapper. It renders the same source as a live diagram in documentation, React
-products, and Grafana dashboards.
-
-| Input | Purpose |
-|---|---|
-| `topology.yaml` | Defines the graph: nodes, links, paths, regions, layers, labels, and data. |
-| `stylesheet.yaml` | Defines presentation: icons, labels, colors, layout, emphasis, and interaction states. |
-| `mapper.yaml` | Optionally binds runtime telemetry to topology objects for operational overlays. |
-
-One model. Multiple surfaces. No stale screenshots.
+TopoViewer transforms declarative YAML models into interactive, schema-validated
+topology diagrams. It keeps topology as version-controlled code instead of
+static screenshots, so diagrams can be reviewed, tested, reused, embedded, and
+eventually connected to runtime state.
 
 ![Same TopoViewer YAML rendered as an interactive topology diagram](docs/assets/topoviewer-yaml-to-graph-collage.png)
 
-## Why This Exists
+## The Idea
 
-Infrastructure diagrams rot when they are maintained as pictures. Networks
-change, services move, labels drift, dashboards grow, and the diagram becomes a
-historical artifact.
+Most infrastructure diagrams start useful and then rot. A network changes, a
+service moves, a label drifts, a dashboard grows, and the diagram becomes a
+historical picture.
 
-TopoViewer treats topology diagrams as code:
+TopoViewer treats topology as a semantic asset:
 
-- stable object IDs instead of anonymous shapes
-- layers instead of duplicated drawings
-- regions and paths instead of hand-drawn grouping
-- labels and data for selectors, validation, attention, and telemetry mapping
-- reusable stylesheet YAML instead of visual choices copied into every object
-- runtime overlays instead of disconnected dashboard numbers
+| File | Responsibility |
+|---|---|
+| `topology.yaml` | The graph facts: nodes, links, paths, regions, layers, labels, data, and state. |
+| `stylesheet.yaml` | The presentation policy: icons, labels, colors, layout, emphasis, and interaction states. |
+| `mapper.yaml` | Optional runtime binding from telemetry samples to topology objects. |
 
-If a diagram explains production infrastructure, it should be reviewable,
-testable, diffable, reusable, and eventually generated from source data.
+The result is a clean split:
 
-## Try It
+```text
+topology.yaml    stable object identity and relationships
+stylesheet.yaml  reusable visual policy
+mapper.yaml      optional runtime binding
+```
+
+One source can then render across documentation, React applications, authoring
+tools, and operational dashboards.
+
+## Why TopoViewer Exists
+
+Generic drawing tools are excellent for sketches. TopoViewer is for diagrams
+that need to behave more like infrastructure code.
+
+Use TopoViewer when a topology should be:
+
+- **reviewable** as YAML in pull requests
+- **testable** through schemas, semantic validation, and fixtures
+- **reusable** across docs, product UIs, and dashboards
+- **layered** so one model can produce Physical, Logical, Service, or Transport views
+- **semantic** so nodes, links, paths, regions, labels, and state remain meaningful
+- **operational** when runtime telemetry should land on known topology objects
+
+TopoViewer is not trying to replace every diagramming tool. Mermaid,
+Excalidraw, diagrams.net, React Flow, Cytoscape, D3, Grafana, NetBox, Infrahub,
+Containerlab, and inventory APIs are still useful. TopoViewer sits in the gap
+between those worlds: it gives topology diagrams a stable semantic model and a
+renderer that can travel across surfaces.
+
+## Architecture At A Glance
+
+```mermaid
+flowchart TB
+  subgraph Authoring["Authoring Space"]
+    Harness["Browser Harness<br/>(Experimental)"]
+    VSCode["VS Code Extension<br/>(Roadmap)"]
+  end
+
+  subgraph Core["Core Engine (topoviewer)"]
+    Compiler["compileTopoGraph<br/>(Logic)"]
+    View["TopoViewer React<br/>(View)"]
+  end
+
+  subgraph Integrations["Integration Space"]
+    ReactApp["React Application<br/>(Supported)"]
+    MkDocs["MkDocs Plugin<br/>(Supported)"]
+    Grafana["Grafana Panel<br/>(Experimental)"]
+  end
+
+  Harness --> Compiler
+  VSCode --> Compiler
+  Compiler --> View
+  View --> ReactApp
+  View --> MkDocs
+  View --> Grafana
+```
+
+The core package owns the graph logic and React view. Authoring and integration
+surfaces reuse that core instead of inventing their own topology semantics.
+
+## Start Fast
 
 ### Browser Harness
 
-The Harness is the fastest way to author TopoViewer YAML without wiring it into
-another product.
+The Harness is the fastest way to try TopoViewer without wiring it into another
+product.
 
 ```text
 https://asadarafat.github.io/topoviewer/harness/
 ```
 
-Use it to edit topology, stylesheet, and mapper YAML, validate drafts, preview
-the rendered graph, and export Grafana-ready bundles.
+Use it to edit `topology.yaml`, `stylesheet.yaml`, and `mapper.yaml`, validate
+drafts, preview the rendered graph, and export bundles for other surfaces.
 
 ### React
 
@@ -91,18 +142,6 @@ plugins:
 Then use a `topoviewer` fenced block in Markdown to render live YAML examples
 inside documentation.
 
-### Zensical
-
-TopoViewer also publishes a Zensical static-docs view from the same documentation
-source:
-
-```text
-https://asadarafat.github.io/topoviewer/docs/zensical/
-```
-
-This is an adapter surface for the published docs, not a separate installable
-plugin.
-
 ### Grafana Panel
 
 TopoViewer can also render operational topology in Grafana. The topology and
@@ -125,9 +164,21 @@ That command pulls the self-contained lab bundle and starts the local Grafana
 demo environment. Containerlab is used there only to create disposable
 telemetry; it is not a TopoViewer runtime dependency.
 
+### Zensical
+
+TopoViewer also publishes a Zensical static-docs view from the same documentation
+source:
+
+```text
+https://asadarafat.github.io/topoviewer/docs/zensical/
+```
+
+This is an adapter surface for the published docs, not a separate installable
+plugin.
+
 ## Minimal Model
 
-Topology facts:
+`topology.yaml` defines the topology facts:
 
 ```yaml
 graph:
@@ -157,7 +208,7 @@ graph:
       layers: [physical]
 ```
 
-Presentation policy:
+`stylesheet.yaml` defines how those facts should look:
 
 ```yaml
 stylesheet:
@@ -180,39 +231,56 @@ stylesheet:
       lineWidth: 3
 ```
 
+The contract is intentionally simple:
+
 ```text
 model + style = diagram
 model + style + mapper = operational topology view
 ```
 
-## What Makes It Different
+## Core Semantics
 
-TopoViewer is not a generic Mermaid replacement, and it is not only a React Flow
-example. It is a topology-as-code renderer with semantic objects.
+TopoViewer uses semantic topology objects instead of anonymous drawing shapes.
 
 ```text
-node       has identity, labels, data, state, and position
-link       has endpoints, direction, labels, data, and style
-path       models ordered traversal through the graph
-region     groups objects without turning them into pixels
-layer      lets one model produce multiple views
-mapper     attaches runtime telemetry to known topology objects
+node       identity, labels, data, state, position, and visual policy
+link       endpoints, directionality, labels, data, style, and parallel lanes
+path       ordered traversal through the graph
+region     logical grouping without manual drawing
+layer      filtered views from the same model
+mapper     runtime telemetry binding to known topology objects
 ```
 
-That semantic layer is what lets the same topology render in docs, products,
+That semantic layer is what lets the same topology render in docs, product UIs,
 authoring tools, and operational dashboards.
 
-## Project Status
+## Integration Surfaces
+
+TopoViewer provides multiple entry points depending on the use case.
 
 | Surface | Status | Use today |
 |---|---|---|
-| React package | Supported | Install `topoviewer` from npm and embed `TopoViewer`. |
-| MkDocs plugin | Supported | Install `mkdocs-topoviewer` and render live YAML examples. |
+| React package | Supported | Install `topoviewer` from npm and embed the `TopoViewer` component. |
+| MkDocs plugin | Supported | Install `mkdocs-topoviewer` and render live YAML examples in documentation. |
 | Browser Harness | Experimental | Author, validate, preview, and export TopoViewer bundles. |
+| Grafana panel | Experimental | Mount topology/style/mapper bundles and render telemetry-driven overlays. |
 | Zensical | Adapter | Static generated docs adapter, not an installable plugin. |
-| Grafana panel | Experimental | Mounted bundles and mapper-driven runtime overlays, proven through the Containerlab demo path. |
 | VS Code extension | Roadmap | Planned packaged authoring surface; no VSIX is published yet. |
 | NetBox / Infrahub | Roadmap | Future source-of-truth integration surfaces. |
+
+## Where It Fits
+
+TopoViewer is useful when the diagram is no longer just a picture.
+
+| Need | TopoViewer gives you |
+|---|---|
+| Keep diagrams in Git | Declarative YAML with stable IDs and reusable style policy |
+| Review topology changes | Diffs against model, style, and mapper files |
+| Avoid duplicated drawings | Layers, selectors, regions, and paths from one model |
+| Embed in products | React package with exported types and CSS |
+| Publish in docs | MkDocs plugin and generated docs surfaces |
+| Add runtime state | Mapper-driven overlays for operational dashboards |
+| Validate before publish | JSON Schema, semantic linting, and renderer checks |
 
 ## Local Development
 
@@ -315,11 +383,11 @@ Expected boundaries:
 ## Stability Note
 
 TopoViewer is a serious early project. The core package and MkDocs plugin are
-published, but some integration surfaces are still experimental. APIs, examples,
-and lab workflows may change while the project hardens.
+published, while some authoring and operational surfaces are still experimental.
+APIs, examples, and lab workflows may change while the project hardens.
 
 The project prioritizes stable install paths, clear examples, validated inputs,
-and predictable rendering over adding more surfaces.
+and predictable rendering over adding more surfaces too early.
 
 ## License
 

--- a/packages/topoviewer/content/pages/_fragments/readme.md
+++ b/packages/topoviewer/content/pages/_fragments/readme.md
@@ -5,53 +5,104 @@
 [![npm](https://img.shields.io/npm/v/topoviewer?label=npm)](https://www.npmjs.com/package/topoviewer)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/asadarafat/topoviewer)
 
-TopoViewer turns infrastructure topology into interactive diagrams.
+**Topology as Code for infrastructure, network, and service diagrams.**
 
-Give TopoViewer a topology model, a stylesheet, and optionally a telemetry
-mapper. It renders the same source as a live diagram in documentation, React
-products, and Grafana dashboards.
-
-| Input | Purpose |
-|---|---|
-| `topology.yaml` | Defines the graph: nodes, links, paths, regions, layers, labels, and data. |
-| `stylesheet.yaml` | Defines presentation: icons, labels, colors, layout, emphasis, and interaction states. |
-| `mapper.yaml` | Optionally binds runtime telemetry to topology objects for operational overlays. |
-
-One model. Multiple surfaces. No stale screenshots.
+TopoViewer transforms declarative YAML models into interactive, schema-validated
+topology diagrams. It keeps topology as version-controlled code instead of
+static screenshots, so diagrams can be reviewed, tested, reused, embedded, and
+eventually connected to runtime state.
 
 ![Same TopoViewer YAML rendered as an interactive topology diagram](docs/assets/topoviewer-yaml-to-graph-collage.png)
 
-## Why This Exists
+## The Idea
 
-Infrastructure diagrams rot when they are maintained as pictures. Networks
-change, services move, labels drift, dashboards grow, and the diagram becomes a
-historical artifact.
+Most infrastructure diagrams start useful and then rot. A network changes, a
+service moves, a label drifts, a dashboard grows, and the diagram becomes a
+historical picture.
 
-TopoViewer treats topology diagrams as code:
+TopoViewer treats topology as a semantic asset:
 
-- stable object IDs instead of anonymous shapes
-- layers instead of duplicated drawings
-- regions and paths instead of hand-drawn grouping
-- labels and data for selectors, validation, attention, and telemetry mapping
-- reusable stylesheet YAML instead of visual choices copied into every object
-- runtime overlays instead of disconnected dashboard numbers
+| File | Responsibility |
+|---|---|
+| `topology.yaml` | The graph facts: nodes, links, paths, regions, layers, labels, data, and state. |
+| `stylesheet.yaml` | The presentation policy: icons, labels, colors, layout, emphasis, and interaction states. |
+| `mapper.yaml` | Optional runtime binding from telemetry samples to topology objects. |
 
-If a diagram explains production infrastructure, it should be reviewable,
-testable, diffable, reusable, and eventually generated from source data.
+The result is a clean split:
 
-## Try It
+```text
+topology.yaml    stable object identity and relationships
+stylesheet.yaml  reusable visual policy
+mapper.yaml      optional runtime binding
+```
+
+One source can then render across documentation, React applications, authoring
+tools, and operational dashboards.
+
+## Why TopoViewer Exists
+
+Generic drawing tools are excellent for sketches. TopoViewer is for diagrams
+that need to behave more like infrastructure code.
+
+Use TopoViewer when a topology should be:
+
+- **reviewable** as YAML in pull requests
+- **testable** through schemas, semantic validation, and fixtures
+- **reusable** across docs, product UIs, and dashboards
+- **layered** so one model can produce Physical, Logical, Service, or Transport views
+- **semantic** so nodes, links, paths, regions, labels, and state remain meaningful
+- **operational** when runtime telemetry should land on known topology objects
+
+TopoViewer is not trying to replace every diagramming tool. Mermaid,
+Excalidraw, diagrams.net, React Flow, Cytoscape, D3, Grafana, NetBox, Infrahub,
+Containerlab, and inventory APIs are still useful. TopoViewer sits in the gap
+between those worlds: it gives topology diagrams a stable semantic model and a
+renderer that can travel across surfaces.
+
+## Architecture At A Glance
+
+```mermaid
+flowchart TB
+  subgraph Authoring["Authoring Space"]
+    Harness["Browser Harness<br/>(Experimental)"]
+    VSCode["VS Code Extension<br/>(Roadmap)"]
+  end
+
+  subgraph Core["Core Engine (topoviewer)"]
+    Compiler["compileTopoGraph<br/>(Logic)"]
+    View["TopoViewer React<br/>(View)"]
+  end
+
+  subgraph Integrations["Integration Space"]
+    ReactApp["React Application<br/>(Supported)"]
+    MkDocs["MkDocs Plugin<br/>(Supported)"]
+    Grafana["Grafana Panel<br/>(Experimental)"]
+  end
+
+  Harness --> Compiler
+  VSCode --> Compiler
+  Compiler --> View
+  View --> ReactApp
+  View --> MkDocs
+  View --> Grafana
+```
+
+The core package owns the graph logic and React view. Authoring and integration
+surfaces reuse that core instead of inventing their own topology semantics.
+
+## Start Fast
 
 ### Browser Harness
 
-The Harness is the fastest way to author TopoViewer YAML without wiring it into
-another product.
+The Harness is the fastest way to try TopoViewer without wiring it into another
+product.
 
 ```text
 https://asadarafat.github.io/topoviewer/harness/
 ```
 
-Use it to edit topology, stylesheet, and mapper YAML, validate drafts, preview
-the rendered graph, and export Grafana-ready bundles.
+Use it to edit `topology.yaml`, `stylesheet.yaml`, and `mapper.yaml`, validate
+drafts, preview the rendered graph, and export bundles for other surfaces.
 
 ### React
 
@@ -90,18 +141,6 @@ plugins:
 Then use a `topoviewer` fenced block in Markdown to render live YAML examples
 inside documentation.
 
-### Zensical
-
-TopoViewer also publishes a Zensical static-docs view from the same documentation
-source:
-
-```text
-https://asadarafat.github.io/topoviewer/docs/zensical/
-```
-
-This is an adapter surface for the published docs, not a separate installable
-plugin.
-
 ### Grafana Panel
 
 TopoViewer can also render operational topology in Grafana. The topology and
@@ -124,9 +163,21 @@ That command pulls the self-contained lab bundle and starts the local Grafana
 demo environment. Containerlab is used there only to create disposable
 telemetry; it is not a TopoViewer runtime dependency.
 
+### Zensical
+
+TopoViewer also publishes a Zensical static-docs view from the same documentation
+source:
+
+```text
+https://asadarafat.github.io/topoviewer/docs/zensical/
+```
+
+This is an adapter surface for the published docs, not a separate installable
+plugin.
+
 ## Minimal Model
 
-Topology facts:
+`topology.yaml` defines the topology facts:
 
 ```yaml
 graph:
@@ -156,7 +207,7 @@ graph:
       layers: [physical]
 ```
 
-Presentation policy:
+`stylesheet.yaml` defines how those facts should look:
 
 ```yaml
 stylesheet:
@@ -179,39 +230,56 @@ stylesheet:
       lineWidth: 3
 ```
 
+The contract is intentionally simple:
+
 ```text
 model + style = diagram
 model + style + mapper = operational topology view
 ```
 
-## What Makes It Different
+## Core Semantics
 
-TopoViewer is not a generic Mermaid replacement, and it is not only a React Flow
-example. It is a topology-as-code renderer with semantic objects.
+TopoViewer uses semantic topology objects instead of anonymous drawing shapes.
 
 ```text
-node       has identity, labels, data, state, and position
-link       has endpoints, direction, labels, data, and style
-path       models ordered traversal through the graph
-region     groups objects without turning them into pixels
-layer      lets one model produce multiple views
-mapper     attaches runtime telemetry to known topology objects
+node       identity, labels, data, state, position, and visual policy
+link       endpoints, directionality, labels, data, style, and parallel lanes
+path       ordered traversal through the graph
+region     logical grouping without manual drawing
+layer      filtered views from the same model
+mapper     runtime telemetry binding to known topology objects
 ```
 
-That semantic layer is what lets the same topology render in docs, products,
+That semantic layer is what lets the same topology render in docs, product UIs,
 authoring tools, and operational dashboards.
 
-## Project Status
+## Integration Surfaces
+
+TopoViewer provides multiple entry points depending on the use case.
 
 | Surface | Status | Use today |
 |---|---|---|
-| React package | Supported | Install `topoviewer` from npm and embed `TopoViewer`. |
-| MkDocs plugin | Supported | Install `mkdocs-topoviewer` and render live YAML examples. |
+| React package | Supported | Install `topoviewer` from npm and embed the `TopoViewer` component. |
+| MkDocs plugin | Supported | Install `mkdocs-topoviewer` and render live YAML examples in documentation. |
 | Browser Harness | Experimental | Author, validate, preview, and export TopoViewer bundles. |
+| Grafana panel | Experimental | Mount topology/style/mapper bundles and render telemetry-driven overlays. |
 | Zensical | Adapter | Static generated docs adapter, not an installable plugin. |
-| Grafana panel | Experimental | Mounted bundles and mapper-driven runtime overlays, proven through the Containerlab demo path. |
 | VS Code extension | Roadmap | Planned packaged authoring surface; no VSIX is published yet. |
 | NetBox / Infrahub | Roadmap | Future source-of-truth integration surfaces. |
+
+## Where It Fits
+
+TopoViewer is useful when the diagram is no longer just a picture.
+
+| Need | TopoViewer gives you |
+|---|---|
+| Keep diagrams in Git | Declarative YAML with stable IDs and reusable style policy |
+| Review topology changes | Diffs against model, style, and mapper files |
+| Avoid duplicated drawings | Layers, selectors, regions, and paths from one model |
+| Embed in products | React package with exported types and CSS |
+| Publish in docs | MkDocs plugin and generated docs surfaces |
+| Add runtime state | Mapper-driven overlays for operational dashboards |
+| Validate before publish | JSON Schema, semantic linting, and renderer checks |
 
 ## Local Development
 
@@ -314,11 +382,11 @@ Expected boundaries:
 ## Stability Note
 
 TopoViewer is a serious early project. The core package and MkDocs plugin are
-published, but some integration surfaces are still experimental. APIs, examples,
-and lab workflows may change while the project hardens.
+published, while some authoring and operational surfaces are still experimental.
+APIs, examples, and lab workflows may change while the project hardens.
 
 The project prioritizes stable install paths, clear examples, validated inputs,
-and predictable rendering over adding more surfaces.
+and predictable rendering over adding more surfaces too early.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Repositions TopoViewer as a Topology-as-Code visualization library for infrastructure, network, and service diagrams.
- Adds a clearer model split for `topology.yaml`, `stylesheet.yaml`, and optional `mapper.yaml`.
- Adds an architecture-at-a-glance Mermaid diagram reflecting Authoring Space, Core Engine, and Integration Space.
- Tightens integration surface status around React, MkDocs, Browser Harness, Grafana, Zensical, VS Code, and future source-of-truth integrations.
- Keeps the canonical content fragment and generated root `README.md` in sync.

## Validation

- Not run locally. Documentation-only change prepared through GitHub contents API.